### PR TITLE
Fix build paths and tsconfig

### DIFF
--- a/electron-main/main.ts
+++ b/electron-main/main.ts
@@ -17,7 +17,7 @@ function createWindow() {
     },
   });
 
-  mainWindow.loadFile(path.join(__dirname, '../dist/renderer/index.html'));
+  mainWindow.loadFile(path.join(__dirname, '../renderer/index.html'));
 }
 
 app.whenReady().then(() => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,9 @@
     "rootDir": ".",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node", "electron"]
   },
-  "include": ["electron-main/**/*", "shared/**/*", "src/**/*", "tests/**/*"]
+  "include": ["electron-main/**/*", "shared/**/*"],
+  "exclude": ["tests"]
 }


### PR DESCRIPTION
## Summary
- fix Electron load path after build
- add Node/Electron types and exclude tests from tsc

## Testing
- `npm run build`
- `npm test -- -t ''`

------
https://chatgpt.com/codex/tasks/task_e_6846eeaa489c8320854e485ab0702ad4