### PR TITLE
Fix asset paths and add basic e2e test

### DIFF
--- a/electron-main/main.ts
+++ b/electron-main/main.ts
@@ -17,7 +17,16 @@ function createWindow() {
     },
   });
 
-  mainWindow.loadFile(path.join(__dirname, '../dist/renderer/index.html'));
+  mainWindow.loadFile(path.join(__dirname, '../renderer/index.html'));
+  mainWindow.webContents.once('did-fail-load', (_e, code, desc) => {
+    console.error('Load failed', code, desc);
+    if (process.env.E2E_TEST) app.exit(1);
+  });
+  mainWindow.webContents.once('did-finish-load', () => {
+    if (process.env.E2E_TEST) {
+      setTimeout(() => app.exit(0), 500);
+    }
+  });
 }
 
 app.whenReady().then(() => {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "tsc && vite build",
     "start": "npm run build && electron dist/electron-main/main.js",
-    "test": "vitest"
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:e2e": "npm run build && vitest run --config vitest.e2e.config.ts tests/e2e.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/src/index.html
+++ b/src/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self'; script-src 'self'" />
   <link rel="stylesheet" href="../node_modules/github-markdown-css/github-markdown.css">
   <link rel="stylesheet" href="./styles/index.css">
   <title>DocView</title>

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -1,0 +1,24 @@
+import { describe, it } from 'vitest';
+import { spawn } from 'child_process';
+import path from 'path';
+import electron from 'electron';
+
+function runElectron(appPath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(electron as unknown as string, [appPath], {
+      env: { ...process.env, E2E_TEST: '1' },
+      stdio: 'ignore'
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      code === 0 ? resolve() : reject(new Error(`Exit code ${code}`));
+    });
+  });
+}
+
+describe('e2e', () => {
+  it('loads renderer without errors', async () => {
+    const main = path.join(__dirname, '../dist/electron-main/main.js');
+    await runElectron(main);
+  }, 20000);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,9 @@
     "rootDir": ".",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node", "electron"]
   },
-  "include": ["electron-main/**/*", "shared/**/*", "src/**/*", "tests/**/*"]
+  "include": ["electron-main/**/*", "shared/**/*"],
+  "exclude": ["tests"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 export default defineConfig({
   root: path.resolve(__dirname, 'src'),
+  base: './',
   build: {
     outDir: path.resolve(__dirname, 'dist/renderer'),
     emptyOutDir: true,

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    environment: 'node',
-    exclude: ['tests/e2e.test.ts'],
-  },
+    environment: 'node'
+  }
 });


### PR DESCRIPTION
## Summary
- ensure built renderer assets use relative paths by setting `base: './'`
- add non-watch testing scripts and dedicated e2e test runner
- enforce a basic CSP in `index.html`
- allow headless exit hooks for e2e in `main.ts`
- add initial Playwright-free e2e test

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Exit code null)*

------
https://chatgpt.com/codex/tasks/task_e_6846eeaa489c8320854e485ab0702ad4