### PR TITLE
Support headless e2e

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ A window will open asking for a folder. Pick the documentation directory and the
 - `npm run build` – compile TypeScript and bundle the renderer.
 - `npm run start` – build then start the Electron app.
 - `npm test` – run Vitest.
+- End-to-end tests require a display. When running in headless environments,
+  `xvfb-run` must be available. The test harness detects the absence of the
+  `DISPLAY` variable and launches Electron using `xvfb-run` automatically.
 
 ## Architecture
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -5,7 +5,13 @@ import electron from 'electron';
 
 function runElectron(appPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    const child = spawn(electron as unknown as string, [appPath], {
+    const useXvfb = !process.env.DISPLAY;
+    const command = useXvfb ? 'xvfb-run' : (electron as unknown as string);
+    const electronArgs = ['--no-sandbox', appPath];
+    const args = useXvfb
+      ? ['-a', electron as unknown as string, ...electronArgs]
+      : electronArgs;
+    const child = spawn(command, args, {
       env: { ...process.env, E2E_TEST: '1' },
       stdio: 'ignore'
     });


### PR DESCRIPTION
## Summary
- launch Electron under xvfb when DISPLAY is missing
- allow Electron to run as root by adding `--no-sandbox`
- document headless requirement for e2e in README

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68471e1fcfe48320ba71f7afba692f2d