### PR TITLE
Improve FS error handling

### DIFF
--- a/shared/directoryWalker.ts
+++ b/shared/directoryWalker.ts
@@ -7,7 +7,19 @@ const ENTRY_NAMES = ['index.md', 'readme.md', 'doc.md'];
 export async function walkDirectory(root: string, dir = '.'):
   Promise<DirNode> {
   const absDir = path.join(root, dir);
-  const items = await fs.readdir(absDir, { withFileTypes: true });
+  let items: fs.Dirent[] = [];
+  try {
+    items = await fs.readdir(absDir, { withFileTypes: true });
+  } catch (err) {
+    // return partial node if directory can't be read
+    return {
+      type: 'directory',
+      name: path.basename(absDir),
+      path: dir,
+      children: [],
+      entryFile: undefined,
+    };
+  }
   const children: Node[] = [];
   let entryFile: FileNode | undefined;
 

--- a/shared/fileService.ts
+++ b/shared/fileService.ts
@@ -14,6 +14,10 @@ export class FileService {
 
   async readFile(p: string) {
     const full = this.resolveSafe(p);
-    return fs.readFile(full, 'utf-8');
+    try {
+      return await fs.readFile(full, 'utf-8');
+    } catch (err: any) {
+      throw new Error(`Failed to read file ${p}: ${err.message}`);
+    }
   }
 }

--- a/tests/directoryWalker.test.ts
+++ b/tests/directoryWalker.test.ts
@@ -21,4 +21,10 @@ describe('walkDirectory', () => {
     const sub = tree.children.find(c => (c as any).name === 'sub') as any;
     expect(sub.entryFile?.name).toBe('index.md');
   });
+
+  it('returns partial node when directory missing', async () => {
+    const missing = path.join(tempDir, 'does-not-exist');
+    const tree = await walkDirectory(missing);
+    expect(tree.children.length).toBe(0);
+  });
 });

--- a/tests/ipc.test.ts
+++ b/tests/ipc.test.ts
@@ -14,4 +14,12 @@ describe('FileService and parser integration', () => {
     const html = parseMarkdown(md);
     expect(html).toContain('<h1');
   });
+
+  it('throws descriptive error when file missing', async () => {
+    const root = path.join(process.cwd(), 'tmp-ipc-missing');
+    await fs.rm(root, { recursive: true, force: true });
+    await fs.mkdir(root, { recursive: true });
+    const service = new FileService(root);
+    await expect(service.readFile('no.md')).rejects.toThrow('Failed to read file');
+  });
 });


### PR DESCRIPTION
## Summary
- handle fs errors in directory walker and file service
- return partial directory node on read errors
- throw descriptive error messages from FileService
- test failure scenarios for both modules

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68471f28cdb88320bc2870d1d5b61525