### PR TITLE
Implement responsive layout shell

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,13 +5,14 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self'; script-src 'self'" />
-  <link rel="stylesheet" href="../node_modules/github-markdown-css/github-markdown.css">
-  <link rel="stylesheet" href="./styles/index.css">
+  <link rel="stylesheet" href="../node_modules/github-markdown-css/github-markdown.css" />
+  <link rel="stylesheet" href="../node_modules/highlight.js/styles/github-dark.css" />
+  <link rel="stylesheet" href="./styles/index.css" />
   <title>DocView</title>
 </head>
-<body class="h-screen flex">
-  <div id="sidebar" class="w-1/3 h-full overflow-auto border-r"></div>
-  <div id="content" class="markdown-body p-4 w-2/3 h-full overflow-auto"></div>
+<body class="h-screen flex bg-[#1e1e1e] text-[#e4e4e4]">
+  <aside id="sidebar" class="min-w-[200px] max-w-[300px] flex-shrink-0 flex-grow-0 basis-1/5 overflow-auto border-r border-gray-700 bg-[#1e1e1e] text-[#d4d4d4]"></aside>
+  <main id="content" class="markdown-body flex-grow overflow-auto p-8"></main>
   <script type="module" src="./main.ts"></script>
 </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,8 +11,24 @@ type TreeNode = FileNode | DirNode;
 
 const sidebar = document.getElementById('sidebar')!;
 const content = document.getElementById('content')!;
+const openBtn = document.createElement('button');
+openBtn.textContent = 'Open Folder';
+openBtn.className = 'px-4 py-2 bg-blue-600 text-white rounded';
+openBtn.onclick = () => chooseFolder();
 
 let currentRoot: string | null = null;
+let activeEl: HTMLElement | null = null;
+
+function showWelcome() {
+  content.innerHTML = '';
+  const wrap = document.createElement('div');
+  wrap.className = 'h-full flex flex-col items-center justify-center space-y-4';
+  const msg = document.createElement('p');
+  msg.textContent = 'Select folder to begin viewing your Markdown documentation';
+  wrap.appendChild(msg);
+  wrap.appendChild(openBtn);
+  content.appendChild(wrap);
+}
 
 function renderTree(node: DirNode) {
   const ul = document.createElement('ul');
@@ -33,6 +49,9 @@ function renderTree(node: DirNode) {
       a.onclick = (e) => {
         e.preventDefault();
         loadFile(child.path);
+        if (activeEl) activeEl.classList.remove('bg-[#2c2c2c]', 'border-l-4', 'border-blue-500');
+        a.classList.add('bg-[#2c2c2c]', 'border-l-4', 'border-blue-500');
+        activeEl = a;
       };
       li.appendChild(a);
     }
@@ -56,4 +75,4 @@ async function chooseFolder() {
   if (result.tree.entryFile) loadFile(result.tree.entryFile.path);
 }
 
-chooseFolder();
+showWelcome();


### PR DESCRIPTION
## Summary
- style layout with responsive sidebar and viewer
- add highlight.js css for syntax highlighting
- implement "Open Folder" welcome screen in renderer

## Testing
- `npm test`
- `npm run test:e2e` *(fails: spawn xvfb-run ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6847603614b483208eba4ed631a904c5