### PR TITLE
Implement DocView Renderer UI

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,13 +5,18 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self'; script-src 'self'" />
-  <link rel="stylesheet" href="../node_modules/github-markdown-css/github-markdown.css">
   <link rel="stylesheet" href="./styles/index.css">
   <title>DocView</title>
 </head>
-<body class="h-screen flex">
-  <div id="sidebar" class="w-1/3 h-full overflow-auto border-r"></div>
-  <div id="content" class="markdown-body p-4 w-2/3 h-full overflow-auto"></div>
+<body class="flex h-screen bg-gray-900 text-gray-300">
+  <div id="sidebar" class="flex-[0_0_20%] max-w-xs min-w-[200px] overflow-y-auto border-r border-gray-700"></div>
+  <div id="viewer-container" class="flex-grow overflow-y-auto p-8 bg-gray-900 text-gray-100 relative">
+    <div id="welcome" class="absolute inset-0 flex flex-col items-center justify-center">
+      <p class="mb-4 text-center">Select folder to begin viewing your Markdown documentation</p>
+      <button id="open-folder" class="px-4 py-2 bg-blue-600 text-white rounded">Open Folder</button>
+    </div>
+    <div id="content" class="markdown-body hidden"></div>
+  </div>
   <script type="module" src="./main.ts"></script>
 </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,49 +11,99 @@ type TreeNode = FileNode | DirNode;
 
 const sidebar = document.getElementById('sidebar')!;
 const content = document.getElementById('content')!;
+const welcome = document.getElementById('welcome')!;
+const openButton = document.getElementById('open-folder')! as HTMLButtonElement;
 
 let currentRoot: string | null = null;
+let activeLink: HTMLElement | null = null;
 
-function renderTree(node: DirNode) {
-  const ul = document.createElement('ul');
-  for (const child of node.children) {
-    const li = document.createElement('li');
-    if (child.type === 'directory') {
-      li.textContent = child.name;
-      li.classList.add('font-bold', 'cursor-pointer');
-      li.onclick = () => {
-        li.appendChild(renderTree(child));
-        li.onclick = null;
-        if (child.entryFile) loadFile(child.entryFile.path);
-      };
-    } else {
-      const a = document.createElement('a');
-      a.textContent = child.name;
-      a.href = '#';
-      a.onclick = (e) => {
-        e.preventDefault();
-        loadFile(child.path);
-      };
-      li.appendChild(a);
+function setActive(el: HTMLElement) {
+  if (activeLink) activeLink.classList.remove('bg-gray-800', 'border-l-4', 'border-blue-500');
+  activeLink = el;
+  activeLink.classList.add('bg-gray-800', 'border-l-4', 'border-blue-500');
+}
+
+function renderNode(node: TreeNode): HTMLElement {
+  if (node.type === 'directory') {
+    const container = document.createElement('div');
+    const header = document.createElement('div');
+    header.classList.add('cursor-pointer', 'select-none', 'flex', 'items-center', 'py-1', 'pl-2', 'hover:bg-gray-800');
+    const icon = document.createElement('span');
+    icon.textContent = '▸';
+    icon.classList.add('mr-1', 'transition-transform');
+    header.appendChild(icon);
+    const name = document.createElement('span');
+    name.textContent = node.name;
+    header.appendChild(name);
+
+    const childrenEl = document.createElement('div');
+    childrenEl.classList.add('ml-4', 'hidden');
+    for (const child of node.children) {
+      childrenEl.appendChild(renderNode(child));
     }
-    ul.appendChild(li);
+
+    header.onclick = () => {
+      const hidden = childrenEl.classList.toggle('hidden');
+      icon.style.transform = hidden ? '' : 'rotate(90deg)';
+    };
+
+    container.appendChild(header);
+    container.appendChild(childrenEl);
+    return container;
   }
-  return ul;
+
+  const link = document.createElement('a');
+  link.textContent = node.name.replace(/\.md$/i, '');
+  link.href = '#';
+  link.dataset.path = node.path;
+  link.classList.add('block', 'pl-6', 'py-1', 'hover:bg-gray-800');
+  link.onclick = (e) => {
+    e.preventDefault();
+    setActive(link);
+    loadFile(node.path);
+  };
+  return link;
+}
+
+function renderTree(tree: DirNode) {
+  sidebar.innerHTML = '';
+  for (const child of tree.children) {
+    sidebar.appendChild(renderNode(child));
+  }
 }
 
 async function loadFile(p: string) {
   if (!currentRoot) return;
   const html = await api.readFile(p);
   content.innerHTML = html;
+  welcome.classList.add('hidden');
+  content.classList.remove('hidden');
+}
+
+function findFirstFile(node: DirNode): FileNode | null {
+  if (node.entryFile) return node.entryFile;
+  for (const child of node.children) {
+    if (child.type === 'directory') {
+      const found = findFirstFile(child);
+      if (found) return found;
+    } else if (child.type === 'file') {
+      return child;
+    }
+  }
+  return null;
 }
 
 async function chooseFolder() {
   const result = await api.chooseRoot();
   if (!result) return;
   currentRoot = result.root;
-  sidebar.innerHTML = '';
-  sidebar.appendChild(renderTree(result.tree));
-  if (result.tree.entryFile) loadFile(result.tree.entryFile.path);
+  renderTree(result.tree);
+  const first = findFirstFile(result.tree);
+  if (first) {
+    const link = sidebar.querySelector(`[data-path="${first.path}"]`) as HTMLElement;
+    if (link) setActive(link);
+    loadFile(first.path);
+  }
 }
 
-chooseFolder();
+openButton.addEventListener('click', chooseFolder);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,2 +1,4 @@
 @import "../../node_modules/tailwindcss/preflight.css";
+@import "../../node_modules/github-markdown-css/github-markdown.css";
+@import "../../node_modules/highlight.js/styles/github-dark.css";
 @import "../../node_modules/tailwindcss/utilities.css";


### PR DESCRIPTION
## Summary
- add dark-themed HTML layout with a welcome screen
- style using GitHub markdown CSS and highlight.js theme
- implement collapsible sidebar and active file highlighting
- adjust renderer logic for folder selection

## Testing
- `npm test`
- `npm run test:e2e` *(fails: spawn xvfb-run ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68476616af48832080b7f6dfdc9c43dd