### PR TITLE
Implement basic DocView renderer features

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,9 +9,11 @@
   <link rel="stylesheet" href="./styles/index.css">
   <title>DocView</title>
 </head>
-<body class="h-screen flex">
-  <div id="sidebar" class="w-1/3 h-full overflow-auto border-r"></div>
-  <div id="content" class="markdown-body p-4 w-2/3 h-full overflow-auto"></div>
+<body>
+  <div id="app" class="flex h-screen">
+    <aside id="sidebar"></aside>
+    <main id="content"></main>
+  </div>
   <script type="module" src="./main.ts"></script>
 </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,48 +12,79 @@ type TreeNode = FileNode | DirNode;
 const sidebar = document.getElementById('sidebar')!;
 const content = document.getElementById('content')!;
 
-let currentRoot: string | null = null;
+const state = {
+  tree: null as DirNode | null,
+  openDirs: new Set<string>(),
+  activeFile: ''
+};
 
-function renderTree(node: DirNode) {
-  const ul = document.createElement('ul');
-  for (const child of node.children) {
-    const li = document.createElement('li');
+function render() {
+  sidebar.innerHTML = '';
+  if (!state.tree) {
+    content.innerHTML = `<div class="h-full flex items-center justify-center"><button id="openBtn" class="px-4 py-2 bg-blue-600 text-white rounded">Open Folder</button></div>`;
+    document.getElementById('openBtn')!.addEventListener('click', chooseFolder);
+    return;
+  }
+  sidebar.appendChild(renderDir(state.tree, 0));
+}
+
+function renderDir(dir: DirNode, depth: number): HTMLElement {
+  const container = document.createElement('div');
+  if (depth) container.style.paddingLeft = `${depth * 16}px`;
+
+  dir.children.forEach(child => {
     if (child.type === 'directory') {
-      li.textContent = child.name;
-      li.classList.add('font-bold', 'cursor-pointer');
-      li.onclick = () => {
-        li.appendChild(renderTree(child));
-        li.onclick = null;
+      const header = document.createElement('div');
+      header.className = 'cursor-pointer select-none flex items-center';
+      const icon = document.createElement('span');
+      icon.innerHTML = '&#9654;';
+      icon.className = 'mr-1 transition-transform';
+      if (state.openDirs.has(child.path)) icon.classList.add('rotate-90');
+      header.appendChild(icon);
+      const text = document.createElement('span');
+      text.textContent = child.name;
+      header.appendChild(text);
+      header.onclick = () => {
+        if (state.openDirs.has(child.path)) state.openDirs.delete(child.path);
+        else state.openDirs.add(child.path);
+        if (child.entryFile) state.activeFile = child.entryFile.path;
+        render();
         if (child.entryFile) loadFile(child.entryFile.path);
       };
+      container.appendChild(header);
+      if (state.openDirs.has(child.path)) {
+        container.appendChild(renderDir(child, depth + 1));
+      }
     } else {
-      const a = document.createElement('a');
-      a.textContent = child.name;
-      a.href = '#';
-      a.onclick = (e) => {
-        e.preventDefault();
-        loadFile(child.path);
-      };
-      li.appendChild(a);
+      const fileEl = document.createElement('div');
+      fileEl.textContent = child.name.replace(/\.md$/i, '');
+      fileEl.className = 'cursor-pointer pl-4';
+      if (state.activeFile === child.path) fileEl.classList.add('active-file');
+      fileEl.onclick = () => loadFile(child.path);
+      container.appendChild(fileEl);
     }
-    ul.appendChild(li);
-  }
-  return ul;
+  });
+  return container;
 }
 
 async function loadFile(p: string) {
-  if (!currentRoot) return;
   const html = await api.readFile(p);
+  state.activeFile = p;
   content.innerHTML = html;
+  render();
 }
 
 async function chooseFolder() {
   const result = await api.chooseRoot();
   if (!result) return;
-  currentRoot = result.root;
-  sidebar.innerHTML = '';
-  sidebar.appendChild(renderTree(result.tree));
-  if (result.tree.entryFile) loadFile(result.tree.entryFile.path);
+  state.tree = result.tree;
+  state.openDirs = new Set([result.tree.path]);
+  render();
+  if (result.tree.entryFile) {
+    await loadFile(result.tree.entryFile.path);
+  } else {
+    content.innerHTML = '';
+  }
 }
 
-chooseFolder();
+render();

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,2 +1,28 @@
 @import "../../node_modules/tailwindcss/preflight.css";
 @import "../../node_modules/tailwindcss/utilities.css";
+
+body {
+  background-color: #1e1e1e;
+  color: #e4e4e4;
+}
+
+#sidebar {
+  background-color: #1e1e1e;
+  color: #d4d4d4;
+  min-width: 200px;
+  max-width: 300px;
+  flex-shrink: 0;
+  overflow-y: auto;
+  border-right: 1px solid #3f3f3f;
+}
+
+#content {
+  flex-grow: 1;
+  overflow-y: auto;
+  padding: 2rem;
+}
+
+.active-file {
+  background-color: #2c2c2c;
+  border-left: 3px solid #3b82f6;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,6 @@
     "skipLibCheck": true,
     "types": ["node", "electron"]
   },
-  "include": ["electron-main/**/*", "shared/**/*"],
+  "include": ["electron-main/**/*", "shared/**/*", "src/**/*"],
   "exclude": ["tests"]
 }


### PR DESCRIPTION
## Summary
- add UI shell with sidebar and content regions
- expand renderer logic to manage folder tree and selected files
- style the app with a simple dark theme
- compile renderer files via tsconfig

## Testing
- `npm run build`
- `npm test`
- `npm run test:e2e` *(fails: spawn xvfb-run ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_684765321ed08320bf74818f7393d155